### PR TITLE
Update to pytorch 1.0

### DIFF
--- a/layers.py
+++ b/layers.py
@@ -97,6 +97,8 @@ class SpGraphAttentionLayer(nn.Module):
         self.special_spmm = SpecialSpmm()
 
     def forward(self, input, adj):
+        dv = 'cuda' if input.is_cuda else 'cpu'
+
         N = input.size()[0]
         edge = adj.nonzero().t()
 
@@ -112,7 +114,7 @@ class SpGraphAttentionLayer(nn.Module):
         assert not torch.isnan(edge_e).any()
         # edge_e: E
 
-        e_rowsum = self.special_spmm(edge, edge_e, torch.Size([N, N]), torch.ones(size=(N,1)).cuda())
+        e_rowsum = self.special_spmm(edge, edge_e, torch.Size([N, N]), torch.ones(size=(N,1), device=dv))
         # e_rowsum: N x 1
 
         edge_e = self.dropout(edge_e)

--- a/train.py
+++ b/train.py
@@ -93,13 +93,13 @@ def train(epoch):
     loss_val = F.nll_loss(output[idx_val], labels[idx_val])
     acc_val = accuracy(output[idx_val], labels[idx_val])
     print('Epoch: {:04d}'.format(epoch+1),
-          'loss_train: {:.4f}'.format(loss_train.data[0]),
-          'acc_train: {:.4f}'.format(acc_train.data[0]),
-          'loss_val: {:.4f}'.format(loss_val.data[0]),
-          'acc_val: {:.4f}'.format(acc_val.data[0]),
+          'loss_train: {:.4f}'.format(loss_train.data.item()),
+          'acc_train: {:.4f}'.format(acc_train.data.item()),
+          'loss_val: {:.4f}'.format(loss_val.data.item()),
+          'acc_val: {:.4f}'.format(acc_val.data.item()),
           'time: {:.4f}s'.format(time.time() - t))
 
-    return loss_val.data[0]
+    return loss_val.data.item()
 
 
 def compute_test():


### PR DESCRIPTION
1) Small update to get things running on pytorch 1+: using .item() instead of [0] for retrieving scalars. 
2) Fix bug where sparse version assumed cuda. 
