### PR TITLE
Hey, I fixed an IndexError inside train.py that is faced by many people in the issues section.

### DIFF
--- a/train.py
+++ b/train.py
@@ -108,8 +108,8 @@ def compute_test():
     loss_test = F.nll_loss(output[idx_test], labels[idx_test])
     acc_test = accuracy(output[idx_test], labels[idx_test])
     print("Test set results:",
-          "loss= {:.4f}".format(loss_test.data[0]),
-          "accuracy= {:.4f}".format(acc_test.data[0]))
+          "loss= {:.4f}".format(loss_test.data.item()),
+          "accuracy= {:.4f}".format(acc_test.data.item()))
 
 # Train model
 t_total = time.time()


### PR DESCRIPTION
Hi Diego,

In compute_test() function in the train.py script, lines 111 and 112:
In line 111, loss_test.data[0] causes the following error:
Fixing IndexError: invalid index of a 0-dim tensor.
It should be loss_test.data.item(), and the same for 112 as well.

Best regards.
Ahmed Hamido